### PR TITLE
fix: solve error when argument root-path is null

### DIFF
--- a/fgvc/utils/experiment.py
+++ b/fgvc/utils/experiment.py
@@ -235,6 +235,8 @@ def load_config(
     config
         Dictionary with experiment configuration.
     """
+    root_path = root_path or "."
+
     # load config
     with open(config_path) as f:
         config = yaml.safe_load(f)


### PR DESCRIPTION
## :memo: Changelog

- [x] Fix error when argument root-path is null.
