### PR TITLE
fix: mixup batch size and output error

### DIFF
--- a/fgvc/core/training/base_trainer.py
+++ b/fgvc/core/training/base_trainer.py
@@ -78,7 +78,7 @@ class BaseTrainer:
         imgs, targs = batch[0], batch[1]
         imgs, targs = to_device(imgs, targs, device=self.device)
         # apply Mixup or Cutmix if MixupMixin is used in the final class
-        targs_ = targs  # keep original targets to return in the function
+        targs_ = targs  # keep original targets to return by the method
         if hasattr(self, "apply_mixup") and len(imgs) % 2 == 0:  # batch size should be even
             imgs, targs = self.apply_mixup(imgs, targs)
 

--- a/fgvc/core/training/base_trainer.py
+++ b/fgvc/core/training/base_trainer.py
@@ -78,7 +78,7 @@ class BaseTrainer:
         imgs, targs = batch[0], batch[1]
         imgs, targs = to_device(imgs, targs, device=self.device)
         # apply Mixup or Cutmix if MixupMixin is used in the final class
-        if hasattr(self, "apply_mixup"):
+        if hasattr(self, "apply_mixup") and len(imgs) % 2 == 0:  # batch size should be even
             imgs, targs = self.apply_mixup(imgs, targs)
 
         preds = self.model(imgs)

--- a/fgvc/core/training/base_trainer.py
+++ b/fgvc/core/training/base_trainer.py
@@ -78,6 +78,7 @@ class BaseTrainer:
         imgs, targs = batch[0], batch[1]
         imgs, targs = to_device(imgs, targs, device=self.device)
         # apply Mixup or Cutmix if MixupMixin is used in the final class
+        targs_ = targs  # keep original targets to return in the function
         if hasattr(self, "apply_mixup") and len(imgs) % 2 == 0:  # batch size should be even
             imgs, targs = self.apply_mixup(imgs, targs)
 
@@ -90,7 +91,7 @@ class BaseTrainer:
         loss.backward()
 
         # convert to numpy
-        preds, targs = to_numpy(preds, targs)
+        preds, targs = to_numpy(preds, targs_)
         return BatchOutput(preds, targs, _loss)
 
     def predict_batch(self, batch: tuple, *, model: nn.Module = None) -> BatchOutput:


### PR DESCRIPTION
## :memo: Changelog

- [x] Fix mixup related error in `train_batch` method when batch size is not even.
- [x] Fix `train_batch` method to return original targets instead of mixup-adjusted values.

## :link: Links

## :white_check_mark: Checklist

- [x] Lint and tests pass locally with my changes
- [x] I've added tests that prove my feature works or that my fix is effective
- [x] I've added necessary documentation
