### PR TITLE
ci: fix sphinx docs pipeline

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -2,11 +2,15 @@ name: Sphinx Publish
 
 on:
   push:
-    branches:
-      - main
-      - dev
-    paths:
-      - 'docs/**'
+    tags:
+      - 'v*'
+    branches:  # temporary for testing
+      - ci/fix-sphinx-docs-pipeline
+#    branches:
+#      - main
+#      - dev
+#    paths:
+#      - 'docs/**'
 
 jobs:
   build:

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -25,7 +25,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        pip install torch==1.13.1 torchvision==0.14.1 --extra-index-url https://download.pytorch.org/whl/cpu
+        pip install -e .
     - name: Build HTML
       uses: ammaraskar/sphinx-action@master
     - name: Upload artifact

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-    branches:  # temporary for testing
-      - ci/fix-sphinx-docs-pipeline
 #    branches:
 #      - main
 #      - dev
@@ -24,8 +22,8 @@ jobs:
       uses: actions/configure-pages@v3
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install tox
+        pip install -U pip
+        pip install -U tox
     - name: Build HTML
       run: |
         tox run -e docs

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -25,15 +25,15 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install torch==1.13.1 torchvision==0.14.1 --extra-index-url https://download.pytorch.org/whl/cpu
-        pip install -e .
+        pip install tox
     - name: Build HTML
-      uses: ammaraskar/sphinx-action@master
+      run: |
+        tox run -e docs
     - name: Upload artifact
       uses: actions/upload-pages-artifact@v1
       with:
         name: github-pages
-        path: docs/build/html/
+        path: docs/build/
 
   deploy:
     name: Deploy to GitHub Pages

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,10 +6,6 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-import sys
-
-sys.path.append("..")
-
 
 project = "FGVC"
 copyright = "2023, Rail Chamidullin, Lukas Picek"

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,10 @@ commands =
 [testenv:docs]
 description = build documentation
 deps =
-  -r requirements.txt
+  --extra-index-url https://download.pytorch.org/whl/cpu
+  torch==1.13.1
+  torchvision==0.14.1
+  -e .
   -r docs/requirements.txt
 changedir = docs
 commands =


### PR DESCRIPTION
## :memo: Changelog

- [x] Fix CI/CD pipeline for deploying Sphinx documentation page. Use `tox` script instead of third-party GitHub Action.

## :link: Links

## :white_check_mark: Checklist

- [x] Lint and tests pass locally with my changes
- [ ] I've added tests that prove my feature works or that my fix is effective
- [ ] I've added necessary documentation
